### PR TITLE
Make it work in firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitphy",
   "author": "Kevin Wu",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Gifs in your Github",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "serve-docs": "python -m http.server --directory docs"
   },
   "browserslist": [
-    "last 2 Chrome versions"
+    "last 2 Chrome versions",
+    "last 2 Firefox versions"
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ class Popover {
     oldContentNode.parentNode.replaceChild(newContentNode, oldContentNode);
 
     // As images come in, update the img tag to show the image.
-    const promises = gifs.forEach(async (gif, idx) => {
+    gifs.forEach(async (gif, idx) => {
       const r = await fetch(gif.images.fixed_width.url);
       const b = await r.blob();
       const dataURL = await new Promise((resolve, reject) => {

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ class Popover {
       img.style.backgroundColor = randomColor({ luminosity: "bright" });
       img.setAttribute("data-gif-url", gif.images.downsized_medium.url);
       newContentNode.appendChild(img);
-    })
+    });
     oldContentNode.parentNode.replaceChild(newContentNode, oldContentNode);
 
     // As images come in, update the img tag to show the image.
@@ -172,7 +172,7 @@ const _handleTextareaChange = async (event) => {
         await popover.renderGifs(gifs);
       }
     } catch (err) {
-      throw (err);
+      throw err;
     }
 
     prevQuery = query;

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,6 @@ class Popover {
 
     // As images come in, update the img tag to show the image.
     const promises = gifs.forEach(async (gif, idx) => {
-      // Fetching
       const r = await fetch(gif.images.fixed_width.url);
       const b = await r.blob();
       const dataURL = await new Promise((resolve, reject) => {

--- a/src/index.js
+++ b/src/index.js
@@ -117,11 +117,15 @@ const _handleTextareaChange = async (event) => {
   if (query && prevQuery !== query) {
     popover.renderLoading(query);
 
-    const { data: gifs } = await giphy.search(query, { limit: 100 });
-    if (gifs.length === 0) {
-      popover.renderNoResults(query);
-    } else {
-      popover.renderGifs(gifs);
+    try {
+      const { data: gifs } = await giphy.search(query, { limit: 100 });
+      if (gifs.length === 0) {
+        popover.renderNoResults(query);
+      } else {
+        popover.renderGifs(gifs);
+      }
+    } catch (err) {
+      throw (err);
     }
 
     prevQuery = query;

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,14 @@ class Popover {
     this._popover.destroy();
   }
 
+  _createImgNode(gif) {
+    const img = document.createElement("img");
+    img.className = "gitphy--gif";
+    img.style.backgroundColor = randomColor({ luminosity: "bright" });
+    img.setAttribute("data-gif-url", gif.images.downsized_medium.url);
+    return img;
+  }
+
   _getContentNode() {
     return document.querySelector(".gitphy--popover-content");
   }
@@ -85,10 +93,7 @@ class Popover {
     const newContentNode = oldContentNode.cloneNode(false);
     // Fill in img tags with no src, but background
     gifs.forEach((gif, idx) => {
-      const img = document.createElement("img");
-      img.className = "gitphy--gif";
-      img.style.backgroundColor = randomColor({ luminosity: "bright" });
-      img.setAttribute("data-gif-url", gif.images.downsized_medium.url);
+      const img = this._createImgNode(gif);
       newContentNode.appendChild(img);
     });
     oldContentNode.parentNode.replaceChild(newContentNode, oldContentNode);
@@ -112,11 +117,8 @@ class Popover {
   renderGifsNoCSP(gifs) {
     const gifEls = gifs
       .map((gif) => {
-        const img = document.createElement("img");
-        img.className = "gitphy--gif";
-        img.style.backgroundColor = randomColor({ luminosity: "bright" });
+        const img = this._createImgNode(gif);
         img.setAttribute("src", gif.images.fixed_width.url);
-        img.setAttribute("data-gif-url", gif.images.downsized_medium.url);
         return img.outerHTML;
       })
       .join("");

--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,8 @@ class Popover {
     }
   }
 
+  // By using data urls, it works around github's Content-Security-Policy
+  // restrictions, but it loads slower and is more memory-intensive.
   async renderGifsAvoidCSP(gifs) {
     const promises = gifs.map(async (gif) => {
       const img = document.createElement("img");
@@ -96,7 +98,8 @@ class Popover {
       img.setAttribute("src", dataURL);
       return img.outerHTML;
     });
-    // Not sure how I feel about this, feels very FOUC-y
+    // Not sure how I feel about this, feels very FOUC-y.
+    // Could try to render as they come in.
     const gifEls = await Promise.all(promises);
     this._render(gifEls.join(""));
   }

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ class Popover {
     const oldContentNode = this._getContentNode();
     const newContentNode = oldContentNode.cloneNode(false);
     // Fill in img tags with no src, but background
-    gifs.forEach((gif, idx) => {
+    gifs.forEach((gif) => {
       const img = this._createImgNode(gif);
       newContentNode.appendChild(img);
     });
@@ -102,8 +102,8 @@ class Popover {
     gifs.forEach(async (gif, idx) => {
       const r = await fetch(gif.images.fixed_width.url);
       const b = await r.blob();
-      const dataURL = await new Promise((resolve, reject) => {
-        var reader = new FileReader();
+      const dataURL = await new Promise((resolve) => {
+        const reader = new FileReader();
         reader.onloadend = () => {
           resolve(reader.result);
         };

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ class Popover {
     this.textarea = textarea;
     // TODO: Check if CSP is in effect, that would be better.
     // Then firefox could be fast on pages without CSP.
-    this.isFirefox = navigator.userAgent.indexOf("Firefox") != -1;
+    this.isFirefox = navigator.userAgent.indexOf("Firefox") !== -1;
   }
 
   show() {

--- a/src/index.js
+++ b/src/index.js
@@ -22,13 +22,13 @@ let prevQuery = null;
 
 class Popover {
   constructor(textarea) {
+    // Also works for firefox, they emulate the chrome object
+    const giphyAttributionURL = chrome.runtime.getURL("giphy-attribution.png");
     const popoverTemplate = `
       <div class="gitphy--popover">
         <div class="gitphy--popover-content"></div>
         <div class="giphy--attribution-wrapper">
-          <img class="giphy--attribution" src="${chrome.extension.getURL(
-            "giphy-attribution.png"
-          )}">
+          <img class="giphy--attribution" src="${giphyAttributionURL}">
         </div>
       </div>
     `;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,6 @@
       "run_at": "document_end"
     }
   ],
-  "content_security_policy": "script-src 'self'; object-src 'self'; img-src 'self' https://media*.giphy.com",
   "permissions": [
     "https://github.com/*",
     "https://*.giphy.com/*"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "gitphy",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "manifest_version": 2,
   "description": "Put gifs in your Github issues and pull requests without leaving the textarea",
   "author": "Kevin Wu",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,6 +18,10 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://github.com/*"],
+  "content_security_policy": "script-src 'self'; object-src 'self'; img-src 'self' https://media*.giphy.com",
+  "permissions": [
+    "https://github.com/*",
+    "https://*.giphy.com/*"
+  ],
   "web_accessible_resources": ["giphy-attribution.png"]
 }


### PR DESCRIPTION
The npm build script should now build an extension that works in both firefox and chrome (at least in my dev testing).

However, I had to change the way images are loaded in firefox. The tricky thing is that firefox doesn't allow extensions to avoid the content security policy. [This is a verrrrrrry long-running issue in firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1267027) that has borked tools such as React/Redux devtools.

The CSP header that github responds with causes firefox to block loading the images when `img` tags are inserted, since they point off-site to `media*.giphy.com`. I work around the CSP with fetch + data URLs, which look like they're from github.com/the extension. This has a performance impact if the gifs are big, of course. Sorry for the ugly hax0ring.

This also includes a few forward-facing small fixes - chrome.runtime, a tiny bit of extra abstraction, etc